### PR TITLE
Fix links to filenames with single quotes

### DIFF
--- a/roam_to_git/fs.py
+++ b/roam_to_git/fs.py
@@ -86,6 +86,7 @@ def note_filename(filename: str):
     filename = filename.lower()
     filename = re.sub(r" ", r"-", filename)
     filename = re.sub(r"[*#?']", r"-", filename)
+    filename = re.sub(r"[,😊⭐➕📝🔥]", r"", filename)
     filename = f"{filename[:-3]}-{file_hash}.md"
     return filename
 

--- a/roam_to_git/fs.py
+++ b/roam_to_git/fs.py
@@ -87,7 +87,8 @@ def note_filename(filename: str):
     filename = re.sub(r" ", r"-", filename)
     filename = re.sub(r"[*#?']", r"-", filename)
     filename = pathvalidate.sanitize_filename(filename, platform=platform.system())
-    filename = f"{filename[:-3]}-{file_hash}.md"
+    # filename = f"{filename[:-3]}-{file_hash}.md"
+    filename = f"{filename[:-3]}.md"
     return filename
 
 

--- a/roam_to_git/fs.py
+++ b/roam_to_git/fs.py
@@ -86,7 +86,7 @@ def note_filename(filename: str):
     filename = filename.lower()
     filename = re.sub(r" ", r"-", filename)
     filename = re.sub(r"[*#?']", r"-", filename)
-    filename = re.sub(r"[,😊⭐➕📝🔥]", r"", filename)
+    filename = pathvalidate.sanitize_filename(filename, platform=platform.system())
     filename = f"{filename[:-3]}-{file_hash}.md"
     return filename
 

--- a/roam_to_git/fs.py
+++ b/roam_to_git/fs.py
@@ -85,7 +85,7 @@ def note_filename(filename: str):
     file_hash = sha1(filename.encode("utf-8")).hexdigest()[:6]
     filename = filename.lower()
     filename = re.sub(r" ", r"-", filename)
-    filename = re.sub(r"[*#?]", r"-", filename)
+    filename = re.sub(r"[*#?']", r"-", filename)
     filename = f"{filename[:-3]}-{file_hash}.md"
     return filename
 


### PR DESCRIPTION
Files like "Dante's Peak" get converted to "dante-s-peak", but the corresponding links do not, leaving a broken connection. This fixes the links to match the file names.